### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new
@@ -23,6 +23,8 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name, :image, :explanation, :price, :category_id, :condition_id, :origin_area_id, :shipping_charge_id, :send_day_id).merge(user_id: current_user.id)
+    params.require(:item)
+          .permit(:name, :image, :explanation, :price, :category_id, :condition_id, :origin_area_id, :shipping_charge_id, :send_day_id)
+          .merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,9 +16,13 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params
-    params.require(:item).permit(:name, :image, :explanation, :price, :category_id, :condition_id, :origin_area_id, :shipping_charges_id, :send_day_id).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :image, :explanation, :price, :category_id, :condition_id, :origin_area_id, :shipping_charge_id, :send_day_id).merge(user_id: current_user.id)
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,7 +4,7 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-require("turbolinks").start()
+//require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 require("../new")

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,7 +14,7 @@ class Item < ApplicationRecord
   validates :price, presence: true,
                     numericality: { only_integer: true, greater_than: 299, less_than: 9_999_999 },
                     format: { with: /\A\d+\z/ }
-  validates :category_id, :condition_id, :origin_area_id, :shipping_charges_id, :send_day_id,
+  validates :category_id, :condition_id, :origin_area_id, :shipping_charge_id, :send_day_id,
             presence: true, numericality: { other_than: 1 }
   validates :user, presence: true
 end

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,5 +1,5 @@
 <li class='list'>
-  <%= link_to '#' do %>
+  <%= link_to item_path(item.id) do %>
     <%= image_tag item.image, class: "item-img" %>
     <% if @items %> 
       <div class='item-info'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,6 +125,7 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
+
   <% if @items %>
     <%= render partial: 'item', collection: @items %>
   <% else %>
@@ -154,6 +155,7 @@
           </div>
         </div>
       <% end %>
+
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -68,7 +68,7 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_charges_id, ShippingCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_charge_id, ShippingCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,16 +7,18 @@
       <%= "商品名" %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
+      <% unless @item %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
+      <% end %>
     </div>
+    
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -24,45 +26,46 @@
     </div>
 
     <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% elsif @item && user_signed_in? %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% else %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
+    <% end %>
     <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.origin_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.send_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,7 +8,7 @@
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
+      <%# 商品が売れている場合は、sold outの表示 %>
       <% unless @item %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -25,18 +25,16 @@
       </span>
     </div>
 
-    <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
+    <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示%>
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <%# 商品が売れていない場合の表示 %>
     <% elsif @item && user_signed_in? %>
       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% else %>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
-    <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう %>
 
     <div class="item-explain-box">
       <span><%= @item.explanation %></span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:new, :create ]
+  resources :items, only: [:new, :create, :show ]
 end

--- a/db/migrate/20200901072759_create_items.rb
+++ b/db/migrate/20200901072759_create_items.rb
@@ -7,7 +7,7 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer    :category_id,         null: false
       t.integer    :condition_id,        null: false
       t.integer    :origin_area_id,      null: false
-      t.integer    :shipping_charges_id, null: false
+      t.integer    :shipping_charge_id,  null: false
       t.integer    :send_day_id,         null: false
       t.references :user,                null: false, foreign_key: true
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 2020_09_02_033526) do
     t.integer "category_id", null: false
     t.integer "condition_id", null: false
     t.integer "origin_area_id", null: false
-    t.integer "shipping_charges_id", null: false
+    t.integer "shipping_charge_id", null: false
     t.integer "send_day_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :item do
     name { Faker::Name.initials }
     category_id { Faker::Number.within(range: 2..11) }
-    shipping_charges_id { Faker::Number.within(range: 2..3) }
+    shipping_charge_id { Faker::Number.within(range: 2..3) }
     origin_area_id { Faker::Number.within(range: 2..48) }
     send_day_id { Faker::Number.within(range: 2..4) }
     condition_id { Faker::Number.within(range: 2..7) }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -50,14 +50,14 @@ RSpec.describe Item, type: :model do
       end
 
       it '配送料負担の選択がされていないと保存できない' do
-        @item.shipping_charges_id = nil
+        @item.shipping_charge_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping charges can't be blank")
+        expect(@item.errors.full_messages).to include("Shipping charge can't be blank")
       end
       it '配送料負担の選択がid1の場合（未選択）の場合保存ができない' do
-        @item.shipping_charges_id = 1
+        @item.shipping_charge_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Shipping charges must be other than 1')
+        expect(@item.errors.full_messages).to include('Shipping charge must be other than 1')
       end
 
       it '発送元の地域についての情報が選択されていないと保存できない' do


### PR DESCRIPTION
#What
 商品詳細表示機能の実装
#Why
商品詳細ページを見れるようにする

コードレビューをお願いいたします。
（コミット名が”カラム名の訂正”の中にログインの有無で表示を変更するコードが入っています。）

ログイン中のユーザーの商品詳細画面↓
https://gyazo.com/929dd3d05e4bfdf7e54540d82b214a69

ログアウト中のユーザーの商品詳細画面↓
https://gyazo.com/5f4a80cccf4f63f71706e9715f25c80a

出品者の商品詳細画面↓
https://gyazo.com/5261963b924a43bee68cc66aadc0a428